### PR TITLE
feat: Add initial Dashboard & Leaderboard UI

### DIFF
--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -1,9 +1,10 @@
 ﻿import React from 'react';
 
 const AboutPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">AboutPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
-    </div>
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">AboutPage</h1>
+    <p className="text-gray-600">Page under construction – start building!</p>
+  </div>
 );
+
 export default AboutPage;

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -1,9 +1,10 @@
 ﻿import React from 'react';
 
 const AuthPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">AuthPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
-    </div>
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">AuthPage</h1>
+    <p className="text-gray-600">Page under construction – start building!</p>
+  </div>
 );
+
 export default AuthPage;

--- a/src/pages/CollaboratorPage.jsx
+++ b/src/pages/CollaboratorPage.jsx
@@ -1,9 +1,10 @@
 ﻿import React from 'react';
 
 const CollaboratorPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">CollaboratorPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
-    </div>
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">CollaboratorPage</h1>
+    <p className="text-gray-600">Page under construction – start building!</p>
+  </div>
 );
+
 export default CollaboratorPage;

--- a/src/pages/DailyArticlePage.jsx
+++ b/src/pages/DailyArticlePage.jsx
@@ -1,9 +1,10 @@
 ﻿import React from 'react';
 
 const DailyArticlePage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">DailyArticlePage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
-    </div>
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">DailyArticlePage</h1>
+    <p className="text-gray-600">Page under construction – start building!</p>
+  </div>
 );
+
 export default DailyArticlePage;

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,9 +1,209 @@
-﻿import React from 'react';
+﻿import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 
-const DashboardPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">DashboardPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
+// Mock data (replace with real data from Firebase/Auth or API)
+const mockUserStats = {
+  streak: 7,
+  totalWords: 15000,
+  avgWordsPerDay: 2143,
+};
+
+const mockUser = {
+  name: 'Kunal Sharma',
+  email: 'kunal@example.com',
+  summary: 'Avid reader and tech enthusiast passionate about learning and exploring new topics.',
+};
+
+// Mock articles (replace with API-based recommendations)
+const mockArticles = [
+  {
+    id: 1,
+    title: 'Economy Update: GDP Growth',
+    preview: 'India\'s GDP is projected to grow by 7.5% in the next quarter, driven by strong manufacturing and services sectors. Key factors include increased exports and government spending on infrastructure, which are expected to boost economic stability. Analysts predict a positive outlook if current trends continue, with potential impacts on job creation and inflation rates.',
+    topic: 'Economy',
+    source: 'Economic Times',
+  },
+  {
+    id: 2,
+    title: 'Environmental Policies in India',
+    preview: 'New policies aim to reduce carbon emissions by 45% by 2030, focusing on renewable energy sources like solar and wind. The government is offering incentives for green tech adoption, targeting a sustainable future. Challenges include funding and public awareness, but experts see this as a critical step toward net-zero goals.',
+    topic: 'Environment',
+    source: 'The Hindu',
+  },
+  {
+    id: 3,
+    title: 'International Relations: India-US Ties',
+    preview: 'A recent summit has strengthened bilateral ties between India and the US, with agreements on defense and technology transfer. The focus is on countering regional threats and boosting trade, with both nations committing to joint military exercises. This partnership could reshape global alliances in the coming years.',
+    topic: 'IR',
+    source: 'BBC News',
+  },
+  {
+    id: 4,
+    title: 'Master DSA with GeeksforGeeks',
+    preview: 'GeeksforGeeks offers a comprehensive guide to Data Structures and Algorithms (DSA), ideal for coding enthusiasts. With tutorials on arrays, linked lists, and dynamic programming, it’s a go-to resource for preparing for interviews at top tech companies. Practice problems range from beginner to advanced levels.',
+    topic: 'Tech/Education',
+    source: 'GeeksforGeeks',
+  },
+  {
+    id: 5,
+    title: 'CodeChef Contests This Month',
+    preview: 'CodeChef is hosting multiple coding contests this month, featuring challenges for all skill levels. Participants can earn ratings and prizes, with problems designed to enhance problem-solving skills. The platform also provides editorials and tutorials post-contest to aid learning.',
+    topic: 'Tech/Education',
+    source: 'CodeChef',
+  },
+  {
+    id: 6,
+    title: 'LeetCode Premium Problems',
+    preview: 'LeetCode’s premium subscription unlocks advanced problems and mock interviews, perfect for tech job preparation. Topics include system design and optimized solutions, with a community-driven approach to learning. It’s a valuable tool for mastering competitive programming.',
+    topic: 'Tech/Education',
+    source: 'LeetCode',
+  },
+];
+
+const DashboardPage = () => {
+  const [stats, setStats] = useState(mockUserStats);
+  const [articles, setArticles] = useState(mockArticles);
+  const [currentArticleIndex, setCurrentArticleIndex] = useState(0);
+  const [hasDailyGoal, setHasDailyGoal] = useState(false);
+  const [dailyGoal, setDailyGoal] = useState(2000);
+  const [streakHistory, setStreakHistory] = useState([
+    { day: 1, words: 1000 },
+    { day: 2, words: 1200 },
+    { day: 3, words: 1500 },
+    { day: 4, words: 1800 },
+    { day: 7, words: 2000 },
+  ]);
+
+  useEffect(() => {
+    // TODO: Fetch real data from Firebase/Auth for user and stats
+    // TODO: Fetch API-based recommendations (e.g., GFG, CodeChef, LeetCode APIs)
+    // Example API call structure:
+    // fetch('https://api.example.com/articles?topics=tech,education')
+    //   .then(response => response.json())
+    //   .then(data => setArticles(data));
+
+    // Auto-advance carousel every 5 seconds
+    const interval = setInterval(() => {
+      setCurrentArticleIndex((prev) => (prev + 1) % articles.length);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [articles.length]);
+
+  const handleAddWords = () => {
+    setStats((prev) => ({
+      ...prev,
+      totalWords: prev.totalWords + 1000,
+      avgWordsPerDay: Math.round((prev.totalWords + 1000) / (prev.streak + 1)),
+    }));
+  };
+
+  const toggleDailyGoal = () => {
+    setHasDailyGoal(!hasDailyGoal);
+    if (!hasDailyGoal) setDailyGoal(2000); // Default goal
+  };
+
+  const progress = hasDailyGoal ? Math.min((stats.avgWordsPerDay / dailyGoal) * 100, 100) : 0;
+
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-blue-100 to-gray-100 p-6 font-sans text-gray-800'>
+      {/* Sidebar for Quick Access and User Info - Always visible */}
+      <aside className='fixed top-0 left-0 h-full w-64 bg-white shadow-lg p-6 flex flex-col justify-between'>
+        <div>
+          <h1 className='text-2xl font-medium mb-8'>EditorialChain</h1>
+          {/* Highlighted User Information */}
+          <div className='mb-6 p-4 bg-indigo-50 border-l-4 border-indigo-500 rounded-r-lg'>
+            <h3 className='text-lg font-medium text-indigo-700'>Welcome, {mockUser.name}</h3>
+            <p className='text-sm text-gray-600'>{mockUser.email}</p>
+            <p className='text-sm text-gray-600 mt-1'>{mockUser.summary}</p>
+          </div>
+          {/* Navigation */}
+          <nav className='flex flex-col space-y-4'>
+            <Link to='/leaderboard' className='text-lg hover:text-indigo-600 transition-colors'>Leaderboard</Link>
+            <Link to='/settings' className='text-lg hover:text-indigo-600 transition-colors'>Settings</Link>
+            <Link to='/about' className='text-lg hover:text-indigo-600 transition-colors'>About</Link>
+          </nav>
+        </div>
+        <button className='text-sm text-gray-500 hover:text-gray-700' onClick={handleAddWords}>
+          Add 1000 Words (Test)
+        </button>
+      </aside>
+
+      {/* Main Content */}
+      <main className='ml-64 p-6'>
+        {/* Stats Section with Streak Visualization */}
+        <section className='mb-12'>
+          <h2 className='text-2xl font-medium mb-4'>Your Progress</h2>
+          <div className='grid grid-cols-1 md:grid-cols-3 gap-6'>
+            <div className='bg-white p-4 rounded-lg shadow-md'>
+              <h3 className='text-lg font-medium'>Current Streak</h3>
+              <p className='text-3xl'>{stats.streak} days</p>
+              <div className='mt-2 h-1 bg-gray-200 rounded'>
+                <div style={{ width: `${(stats.streak / 30) * 100}%` }} className='h-full bg-blue-400 rounded'></div>
+              </div>
+              <div className='mt-4 text-sm flex space-x-2'>
+                {streakHistory.map((entry) => (
+                  <div key={entry.day} className='text-center'>
+                    <span>Day {entry.day}: {entry.words}w</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className='bg-white p-4 rounded-lg shadow-md'>
+              <h3 className='text-lg font-medium'>Total Words Read</h3>
+              <p className='text-3xl'>{stats.totalWords.toLocaleString()}</p>
+            </div>
+            <div className='bg-white p-4 rounded-lg shadow-md'>
+              <h3 className='text-lg font-medium'>Avg Words/Day</h3>
+              <p className='text-3xl'>{stats.avgWordsPerDay}</p>
+              <button
+                className='mt-2 text-sm text-blue-500 hover:underline'
+                onClick={toggleDailyGoal}
+              >
+                {hasDailyGoal ? 'Remove Goal' : 'Set Daily Goal'}
+              </button>
+              {hasDailyGoal && (
+                <div className='mt-2'>
+                  <div className='w-full bg-gray-200 rounded-full h-1'>
+                    <div
+                      className='bg-green-400 h-1 rounded-full'
+                      style={{ width: `${progress}%` }}
+                    ></div>
+                  </div>
+                  <span className='text-sm'>Goal: {dailyGoal}w | Progress: {progress.toFixed(1)}%</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Article Carousel */}
+        <section>
+          <h2 className='text-2xl font-medium mb-4'>Recommended Daily Articles</h2>
+          <div className='relative overflow-hidden rounded-lg shadow-md bg-white'>
+            <div
+              className='flex transition-transform duration-500 ease-in-out'
+              style={{ transform: `translateX(-${currentArticleIndex * 100}%)` }}
+            >
+              {articles.map((article) => (
+                <div key={article.id} className='w-full flex-shrink-0 p-6'>
+                  <h3 className='text-xl font-medium mb-2'>{article.title}</h3>
+                  <p className='text-gray-600 mb-4'>
+                    {article.preview.length > 150
+                      ? article.preview.substring(0, 150) + '...'
+                      : article.preview}
+                  </p>
+                  <span className='text-sm text-gray-500'>{article.topic}</span>
+                  <p className='text-xs text-gray-400 mt-1'>Source: {article.source}</p>
+                  <Link to='/article' className='block mt-2 text-blue-500 hover:underline'>Read Now</Link>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
-);
+  );
+};
+
 export default DashboardPage;

--- a/src/pages/LeaderboardPage.jsx
+++ b/src/pages/LeaderboardPage.jsx
@@ -1,9 +1,116 @@
-﻿import React from 'react';
+﻿import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 
-const LeaderboardPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">LeaderboardPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
+// Mock data (replace with real Firebase fetch)
+const mockUsers = [
+  { id: 1, name: 'User1', streak: 15, articlesRead: 45, readingSpeed: 250 },
+  { id: 2, name: 'User2', streak: 22, articlesRead: 60, readingSpeed: 300 },
+  { id: 3, name: 'User3', streak: 10, articlesRead: 30, readingSpeed: 220 },
+  { id: 4, name: 'User4', streak: 18, articlesRead: 50, readingSpeed: 280 },
+  { id: 5, name: 'User5', streak: 5, articlesRead: 20, readingSpeed: 200 },
+  { id: 6, name: 'User6', streak: 12, articlesRead: 35, readingSpeed: 260 },
+  { id: 7, name: 'User7', streak: 8, articlesRead: 25, readingSpeed: 230 },
+];
+
+const LeaderboardPage = () => {
+  const [users, setUsers] = useState(mockUsers);
+  const [sortBy, setSortBy] = useState('streak');
+  const [currentPage, setCurrentPage] = useState(1);
+  const usersPerPage = 5;
+
+  useEffect(() => {
+    sortUsers(sortBy);
+  }, [sortBy]);
+
+  const sortUsers = (criteria) => {
+    const sorted = [...mockUsers].sort((a, b) => b[criteria] - a[criteria]);
+    setUsers(sorted);
+  };
+
+  const handleSort = (criteria) => {
+    setSortBy(criteria);
+  };
+
+  const indexOfLastUser = currentPage * usersPerPage;
+  const indexOfFirstUser = indexOfLastUser - usersPerPage;
+  const currentUsers = users.slice(indexOfFirstUser, indexOfLastUser);
+  const totalPages = Math.ceil(users.length / usersPerPage);
+
+  const paginate = (pageNumber) => setCurrentPage(pageNumber);
+
+  const [following, setFollowing] = useState({});
+
+  const toggleFollow = (userId) => {
+    setFollowing((prev) => ({
+      ...prev,
+      [userId]: !prev[userId],
+    }));
+  };
+
+  return (
+    <div className='p-8 bg-gray-50 min-h-screen'>
+      <h1 className='text-3xl font-bold mb-6 text-center'>Leaderboard</h1>
+      <div className='overflow-x-auto'>
+        <table className='min-w-full bg-white border border-gray-200 rounded-lg shadow-md'>
+          <thead className='bg-indigo-600 text-white'>
+            <tr>
+              <th className='py-3 px-4 text-left cursor-pointer' onClick={() => handleSort('streak')}>
+                Rank
+              </th>
+              <th className='py-3 px-4 text-left cursor-pointer' onClick={() => handleSort('name')}>
+                User
+              </th>
+              <th className='py-3 px-4 text-left cursor-pointer' onClick={() => handleSort('streak')}>
+                Streaks <span className={sortBy === 'streak' ? 'text-yellow-300' : ''}>▼</span>
+              </th>
+              <th className='py-3 px-4 text-left cursor-pointer' onClick={() => handleSort('articlesRead')}>
+                Articles Read <span className={sortBy === 'articlesRead' ? 'text-yellow-300' : ''}>▼</span>
+              </th>
+              <th className='py-3 px-4 text-left cursor-pointer' onClick={() => handleSort('readingSpeed')}>
+                Reading Speed (wpm) <span className={sortBy === 'readingSpeed' ? 'text-yellow-300' : ''}>▼</span>
+              </th>
+              <th className='py-3 px-4 text-left'>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {currentUsers.map((user, index) => (
+              <tr key={user.id} className='hover:bg-gray-100 border-b'>
+                <td className='py-3 px-4'>{indexOfFirstUser + index + 1}</td>
+                <td className='py-3 px-4 font-semibold'>
+                  <Link to={/profile/} className='text-blue-500 hover:underline'>
+                    {user.name}
+                  </Link>
+                </td>
+                <td className='py-3 px-4'>{user.streak}</td>
+                <td className='py-3 px-4'>{user.articlesRead}</td>
+                <td className='py-3 px-4'>{user.readingSpeed}</td>
+                <td className='py-3 px-4'>
+                  <button
+                    className={'px-3 py-1 rounded ' + (following[user.id] ? 'bg-red-500 hover:bg-red-600' : 'bg-blue-500 hover:bg-blue-600') + ' text-white'}
+                    onClick={() => toggleFollow(user.id)}
+                  >
+                    {following[user.id] ? 'Unfollow' : 'Follow'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {/* Pagination */}
+      <div className='mt-4 flex justify-center'>
+        {Array.from({ length: totalPages }, (_, i) => i + 1).map((number) => (
+          <button
+            key={number}
+            className={'mx-1 px-3 py-1 rounded ' + (currentPage === number ? 'bg-indigo-600 text-white' : 'bg-gray-200 hover:bg-gray-300')}
+            onClick={() => paginate(number)}
+          >
+            {number}
+          </button>
+        ))}
+      </div>
     </div>
-);
+  );
+};
+
 export default LeaderboardPage;

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,9 +1,10 @@
 ﻿import React from 'react';
 
 const NotFoundPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">NotFoundPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
-    </div>
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">NotFoundPage</h1>
+    <p className="text-gray-600">Page under construction – start building!</p>
+  </div>
 );
+
 export default NotFoundPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,9 +1,10 @@
 ﻿import React from 'react';
 
 const SettingsPage = () => (
-    <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">SettingsPage</h1>
-        <p className="text-gray-600">Page under construction – start building!</p>
-    </div>
+  <div className="p-8">
+    <h1 className="text-3xl font-bold mb-4">SettingsPage</h1>
+    <p className="text-gray-600">Page under construction – start building!</p>
+  </div>
 );
+
 export default SettingsPage;


### PR DESCRIPTION
This PR builds the initial UI for the DashboardPage and LeaderboardPage as planned.

Dashboard: Includes stats (streak, words), user info, and an article recommendation carousel.

Leaderboard: Includes a sortable and paginated table for user rankings.

Data: Currently uses mock data for development.

**See the video demonstration** 

https://github.com/user-attachments/assets/67ee986e-1fa4-4815-962e-40c935ab2ae0


